### PR TITLE
Add db migration

### DIFF
--- a/db/migration/00-create_database.sql
+++ b/db/migration/00-create_database.sql
@@ -1,0 +1,2 @@
+-- database is automaticaly created by docker-compose
+-- CREATE DATABASE IF NOT EXISTS `rinrinrun` DEFAULT CHARACTER SET utf8mb4;

--- a/db/migration/00-create_user_table.sql
+++ b/db/migration/00-create_user_table.sql
@@ -1,1 +1,0 @@
--- create user table

--- a/db/migration/10-create_user.sql
+++ b/db/migration/10-create_user.sql
@@ -1,0 +1,11 @@
+-- create user table
+
+CREATE TABLE IF NOT EXISTS `mokumoku`.`users` (
+	`id` VARCHAR(64) NOT NULL,
+	`score` INT NOT NULL DEFAULT '0',
+	`total_distance` FLOAT NOT NULL DEFAULT '0' COMMENT 'unit km',
+	`total_time` TIME NOT NULL DEFAULT '0',
+	`created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`updated_at` TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
+	PRIMARY KEY (`id`)
+) ENGINE=InnoDB;

--- a/db/migration/11-create_workout_histories.sql
+++ b/db/migration/11-create_workout_histories.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS `mokumoku`.`workout_histories` (
+	`id` INT unsigned NOT NULL AUTO_INCREMENT,
+	`user_id` VARCHAR(64) NOT NULL,
+	`cource_id` INT unsigned NOT NULL,
+	`geometry_track` LINESTRING NOT NULL,
+	`time` TIME NOT NULL,
+	`created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`updated_at` TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY(`id`)
+) ENGINE=InnoDB;

--- a/db/migration/12-create_cources.sql
+++ b/db/migration/12-create_cources.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS `mokumoku`.`cources` (
+	`id` INT unsigned NOT NULL AUTO_INCREMENT,
+	`landmark_id` INT unsigned NOT NULL,
+	`played_count` INT unsigned NOT NULL DEFAULT '0',
+	`difficulity` TINYINT unsigned NOT NULL DEFAULT '0',
+	`created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`updated_at` TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
+	PRIMARY KEY (`id`)
+) ENGINE=InnoDB;

--- a/db/migration/13-create_landmarks.sql
+++ b/db/migration/13-create_landmarks.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS `mokumoku`.`landmarks` (
+	`id` INT unsigned NOT NULL AUTO_INCREMENT,
+	`name` VARCHAR(64) NOT NULL,
+	`description` TEXT NOT NULL DEFAULT '',
+	`picture_url` TEXT NOT NULL DEFAULT 'https://via.placeholder.com/720x360.png?text=Null+landmark+image',
+	`geometry` POINT NOT NULL,
+    `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`updated_at` TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
+	PRIMARY KEY (`id`)
+) ENGINE=InnoDB;

--- a/db/migration/14-create_landmark_visits.sql
+++ b/db/migration/14-create_landmark_visits.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS `mokumoku`.`landmark_visits` (
+	`id` INT unsigned NOT NULL AUTO_INCREMENT,
+	`workout_history_id` INT(64) unsigned NOT NULL,
+	`landmark_id` INT unsigned NOT NULL,
+	`time` TIME NOT NULL,
+	`created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`updated_at` TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
+	PRIMARY KEY (`id`)
+) ENGINE=InnoDB;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       MYSQL_PASSWORD: controller
     # restart: always
     volumes:
-      - ./db/data:/var/lib/mysql # SQL
+      # - ./db/data:/var/lib/mysql # SQL ; 二回目起動時以降にmigrationが行われないため，こいつは無効化しておく
       - ./db/migration:/docker-entrypoint-initdb.d  # SQL Migrations
 
   python:


### PR DESCRIPTION
でーたべーすのまいぐれーしょんをつくりました！
dockerによる起動間でのえいぞくかは，migrationに影響を与えることがわかったので，無効化した．
テストデータが欲しい場合，今後はdb/migrations/100-insert-{tablename}.sqlなどを作って行くこととする．