### PR TITLE
skip verification on development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       GOOGLE_APPLICATION_CREDENTIALS: '/key.json'
       DB_USER: controller
       DB_PASSWORD: controller
+      SERVER_ENV: 'development'
     expose:
       - '8081'
     ports:

--- a/server/src/api/depends/auth.py
+++ b/server/src/api/depends/auth.py
@@ -1,3 +1,5 @@
+import os
+from random import randint
 from fastapi import Header, HTTPException, Response
 from firebase_admin import auth, exceptions
 
@@ -7,4 +9,11 @@ class FirebaseToken:
   def __init__(self, x_token: str = Header(...)):
     if x_token == None:
       raise HTTPException(403, detail="X-Token verification error: not logged in")
+
+    # on development, skip token verification
+    if os.environ["SERVER_ENV"] == "development":
+      self.uid = "development_" + str(randint(0,1000000))
+      return
+
+    
     self.uid = verify_token(x_token)


### PR DESCRIPTION
開発中にTokenを正しく持っていくのが面倒なので，とりあえず対応．
もし開発中に正しいtokenが必要な場面が出てきたら，docker-compose の SERVER_ENVをproductionに変更する．